### PR TITLE
Parsing error line 3 due to extra ) removed

### DIFF
--- a/sample.config.php
+++ b/sample.config.php
@@ -1,6 +1,6 @@
 <?php
 // Path to the log file
-$log_path = '/home/roger/public_html/wp-content/debug.log' );
+$log_path = '/home/roger/public_html/wp-content/debug.log';
 
 // Array of regular expressions. Each one will be run against each 
 // XDebug error and stack trace. If ANY of the regular expressions


### PR DESCRIPTION
M:xdebug-log-filter t$ ./xdebug-log-filter sample.config.php

Parse error: parse error in
/Users/t/Copy/code/xdebug-log-filter/sample.config.php on line 3
